### PR TITLE
Add JupyterHub singleuser support to EOPF-Zarr container

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -124,5 +124,5 @@ jobs:
           push: true
           tags: |
             yuvraj1989/eopf-zarr-driver:latest
-            yuvraj1989/eopf-zarr-driver:v4.2-updated
+            yuvraj1989/eopf-zarr-driver:v4.3-jupyterhub
           file: eopf-zarr-driver/Dockerfile

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -108,12 +108,13 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      # Log in to Docker Hub
-      - name: Log in to Docker Hub
+      # Log in to EOPF Container Registry
+      - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          registry: https://harbor.user.eopf.eodc.eu/
+          username: ${{ secrets.HARBOR_ROBOT_USER }}
+          password: ${{ secrets.HARBOR_ROBOT_PWD }}
 
       # Build and push image
       - name: Build and push
@@ -123,6 +124,6 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           tags: |
-            yuvraj1989/eopf-zarr-driver:latest
-            yuvraj1989/eopf-zarr-driver:v4.3-jupyterhub
+            harbor.user.eopf.eodc.eu/jupyterdask/eopf-zarr-driver:latest
+            harbor.user.eopf.eodc.eu/jupyterdask/eopf-zarr-driver:v4.3-jupyterhub
           file: eopf-zarr-driver/Dockerfile

--- a/eopf-zarr-driver/Dockerfile
+++ b/eopf-zarr-driver/Dockerfile
@@ -28,6 +28,7 @@ RUN mamba install -y -c conda-forge \
     xarray \
     zarr \
     matplotlib \
+    jupyterhub-singleuser \
     && mamba clean --all -f -y
 
 # Verify GDAL version is in the working range (matches Windows success criteria)


### PR DESCRIPTION
- Added jupyterhub-singleuser package for JupyterHub integration
- Updated to v4.3-jupyterhub with JupyterHub 5.3.0 support
- All core functionality maintained: GDAL 3.10.3, rasterio 1.4.3, EOPF plugin
- Image size: 3.77GB (+110MB for JupyterHub support)
- Updated workflow to publish new version tag