### PR TITLE
Add missing parts for JupyterLab compatibility

### DIFF
--- a/eopf-zarr-driver/Dockerfile
+++ b/eopf-zarr-driver/Dockerfile
@@ -28,6 +28,9 @@ RUN mamba install -y -c conda-forge \
     xarray \
     zarr \
     matplotlib \
+    nbgitpuller \
+    mystmd \
+    jupyterlab-myst \
     jupyterhub-singleuser \
     && mamba clean --all -f -y
 


### PR DESCRIPTION
@Yuvraj198920 I had to add some packages to make this image compatible with JupyterLab. Are there any other updates to be done to build an up to date image? It shouldn't be necessary since it's cloning from GitHub and building the driver, but let me know.

@rtmiz I know how to start a notebook with a custom image, but this image should among the "official" ones right? How would I have to reference it when generating the link to start a notebook?
