### PR TITLE
fix: bump eopf-zarr-driver to v5.0.0 and build only plugin target

### DIFF
--- a/eopf-zarr-driver/Dockerfile
+++ b/eopf-zarr-driver/Dockerfile
@@ -6,7 +6,7 @@ FROM ghcr.io/dask/dask-notebook:latest
 
 LABEL maintainer="EOPF Sample Service"
 LABEL description="EOPF-Zarr GDAL Driver with working ReadAsArray and EOPF plugin functionality"
-LABEL version="4.0.0"
+LABEL version="5.0.0"
 
 USER root
 
@@ -53,7 +53,7 @@ RUN git clone --depth 1 https://github.com/EOPF-Sample-Service/GDAL-ZARR-EOPF.gi
         -DGDAL_LIBRARY="/opt/conda/lib/libgdal.so" \
         -DCMAKE_INSTALL_RPATH="/opt/conda/lib" \
         -DCMAKE_BUILD_RPATH="/opt/conda/lib" && \
-    make -j$(nproc) && \
+    make -j$(nproc) gdal_EOPFZarr && \
     echo "Built EOPF driver with GDAL $(gdal-config --version)" && \
     # SOLUTION: Copy to actual GDAL plugin directory (not custom path)
     cp gdal_EOPFZarr.so /opt/conda/lib/gdalplugins/ && \


### PR DESCRIPTION
## Changes

- **`LABEL version`**: `4.0.0` → `5.0.0` to reflect the [GDAL-ZARR-EOPF v5.0.0 release](https://github.com/EOPF-Sample-Service/GDAL-ZARR-EOPF/releases/tag/v5.0.0)
- **`make -j$(nproc)`** → **`make -j$(nproc) gdal_EOPFZarr`**: builds only the plugin shared library instead of all CMake targets (including test binaries that fail to link due to a `sqlite3_total_changes64` symbol mismatch in the conda environment)

## Why the make change?

The CMake project includes test executables (`test_compatibility`, etc.) that link against system `libgdal`. Inside the conda environment the system sqlite3 does not export `sqlite3_total_changes64`, causing the linker to fail. Building only the `gdal_EOPFZarr` target skips these test binaries and lets the Docker build succeed.

The same fix was applied to both Dockerfiles in the [GDAL-ZARR-EOPF repo](https://github.com/EOPF-Sample-Service/GDAL-ZARR-EOPF/commit/5c338cf).